### PR TITLE
Merging collocation point "drift" and finite-core implementation

### DIFF
--- a/src/AeroMDAO.jl
+++ b/src/AeroMDAO.jl
@@ -30,7 +30,7 @@ export dynamic_pressure, force_coefficient, moment_coefficient, rate_coefficient
 include("Geometry/PanelGeometry/PanelGeometry.jl")
 using .PanelGeometry
 
-export AbstractPanel, AbstractPanel2D, Panel2D, WakePanel2D, AbstractPanel3D, Panel3D, Point2D, collocation_point, p1, p2, p3, p4, transform, panel_normal, midpoint, panel_location, panel_tangent, panel_points, panel_dist, wake_panel, wake_panels, panel_area, reverse_panel, panel_length, transform_panel, panel_angle, panel_vector, panel_velocity, panel_scalar, trailing_edge_panel, get_surface_values
+export AbstractPanel, AbstractPanel2D, Panel2D, WakePanel2D, AbstractPanel3D, Panel3D, Point2D, collocation_point, p1, p2, p3, p4, transform, panel_normal, midpoint, panel_location, panel_tangent, panel_points, panel_dist, wake_panel, wake_panels, panel_area, reverse_panel, panel_length, transform_panel, panel_angle, panel_vector, panel_velocity, panel_scalar, trailing_edge_panel, get_surface_values, average_chord, average_width
 
 
 ## Wing geometry

--- a/src/Aerodynamics/Cases/cases.jl
+++ b/src/Aerodynamics/Cases/cases.jl
@@ -90,14 +90,13 @@ function solve_case(components :: Dict{String, Tuple{Matrix{Panel3D{T}}, Matrix{
 
     # Get required vortex lattice variables, i.e. horseshoes, collocation points and normals
     horseshoes = horseshoe_line.(horsies)
-    collocation_points = horseshoe_point.(horsies)
     horseshoes_arr = [ horseshoe_line.(horses) for horses in horseshoe_panels ]
     
     # Unpack Freestream
     U, α, β, Ω = aircraft_velocity(freestream), freestream.alpha, freestream.beta, freestream.omega
 
     # Solve system
-    Γs = solve_system(horseshoes, collocation_points, normies, U, Ω)
+    Γs = solve_system(horseshoes, normies, U, Ω)
 
     # Reshaping
     panel_sizes = size.(horseshoe_panels)

--- a/src/Aerodynamics/Cases/cases.jl
+++ b/src/Aerodynamics/Cases/cases.jl
@@ -30,10 +30,9 @@ Evaluate a vortex lattice case given an array of `Panel3D`s with associated norm
 function solve_case(horseshoe_panels :: Array{<: Panel3D}, normals, U, α, β, Ω, rho_ref, area_ref, chord_ref, span_ref, r_ref)
     # Make horseshoes and collocation points
     horseshoes = horseshoe_line.(horseshoe_panels)
-    collocation_points = horseshoe_point.(horseshoe_panels)
 
     # Solve system
-    Γs = reshape(solve_system(horseshoes[:], collocation_points[:], normals[:], U, Ω), size(horseshoe_panels))
+    Γs = reshape(solve_system(horseshoes[:], normals[:], U, Ω), size(horseshoe_panels))
 
     # Compute forces and moments
     surface_forces, surface_moments, trefftz_force = case_dynamics(Γs, horseshoes, U, α, β, Ω, rho_ref, r_ref)

--- a/src/Aerodynamics/VortexLattice/VortexLattice.jl
+++ b/src/Aerodynamics/VortexLattice/VortexLattice.jl
@@ -7,12 +7,13 @@ using Rotations
 ## Panel geometry and math tools
 #==========================================================================================#
 
-import ..AeroMDAO: Panel3D, panel_area, panel_coords, midpoint, panel_normal, transform, p1, p2, p3, p4, dynamic_pressure, aerodynamic_coefficients, force_coefficient, moment_coefficient, rate_coefficient, weighted_vector, reshape_array, cartesian_to_freestream, freestream_to_cartesian
+import ..AeroMDAO: Panel3D, panel_area, panel_coords, midpoint, panel_normal, transform, p1, p2, p3, p4, average_chord, average_width, dynamic_pressure, aerodynamic_coefficients, force_coefficient, moment_coefficient, rate_coefficient, weighted_vector, reshape_array, cartesian_to_freestream, freestream_to_cartesian
 
 ## Horseshoe setup
 #==========================================================================================#
 
 include("horseshoes.jl")
+include("finite_core.jl")
 
 export Horseshoe, horseshoe_line, horseshoe_point, bound_leg, bound_leg_center, bound_leg_vector, r1, r2, points, make_horseshoes
 
@@ -44,7 +45,7 @@ Evaluate and return the vortex strengths ``\\Gamma``s given `Horseshoes`, their 
 """
 function solve_system(horseshoes, normals, U, Ω)
     V = map(r -> U + Ω × r, collocation_point.(horseshoes))
-    AIC  = influence_matrix(horseshoes, collocation_point.(horseshoes), normals, -normalize(U))
+    AIC  = influence_matrix(horseshoes, collocation_point.(horseshoes), normals, -normalize(U), true)
     boco = boundary_condition(V, normals)
     Γs 	 = AIC \ boco 
 end

--- a/src/Aerodynamics/VortexLattice/VortexLattice.jl
+++ b/src/Aerodynamics/VortexLattice/VortexLattice.jl
@@ -42,9 +42,9 @@ make_horseshoes(horseshoe_panels) =	@. horseshoe_line(horseshoe_panels), horsesh
 
 Evaluate and return the vortex strengths ``\\Gamma``s given `Horseshoes`, their associated normal vectors (not necessarily the same as the panels' normals), the speed ``U`` and rotation vector ``\\Omega``.
 """
-function solve_system(horseshoes, collocation_points, normals, U, Ω)
-    V = map(r -> U + Ω × r, collocation_points)
-    AIC  = influence_matrix(horseshoes, collocation_points, normals, -normalize(U))
+function solve_system(horseshoes, normals, U, Ω)
+    V = map(r -> U + Ω × r, collocation_point.(horseshoes))
+    AIC  = influence_matrix(horseshoes, collocation_point.(horseshoes), normals, -normalize(U))
     boco = boundary_condition(V, normals)
     Γs 	 = AIC \ boco 
 end

--- a/src/Aerodynamics/VortexLattice/finite_core.jl
+++ b/src/Aerodynamics/VortexLattice/finite_core.jl
@@ -1,0 +1,14 @@
+# Finite-core model
+function bound_leg_velocity(a, b, Γ, ε) 
+    na, nb, σ = norm(a), norm(b), dot(a, b)
+    term_1    = (na^2 - σ) / √(na^2 + ε^2) + (nb^2 - σ) / √(nb^2 + ε^2)
+    term_2    = a × b / (na^2 * nb^2 - σ^2 + ε^2 * (na^2 + nb^2 - 2 * na * nb))
+    
+    Γ/4π * term_1 * term_2
+end
+
+trailing_leg_velocity(r, Γ, u, ε) = Γ/4π * normalize(r) × u / (norm(r) - dot(r, u) + ε^2 / (norm(r) + dot(r, u)))
+trailing_legs_velocities(a, b, Γ, u, ε) = trailing_leg_velocity(a, Γ, u, ε) - trailing_leg_velocity(b, Γ, u, ε)
+total_horseshoe_velocity(a, b, Γ, u, ε) = bound_leg_velocity(a, b, Γ, ε) + trailing_legs_velocities(a, b, Γ, u, ε)
+
+horseshoe_velocity(r, line :: Line, Γ, direction, ε) = total_horseshoe_velocity(r1(r, line), r2(r, line), Γ, direction, ε)

--- a/src/Aerodynamics/VortexLattice/horseshoes.jl
+++ b/src/Aerodynamics/VortexLattice/horseshoes.jl
@@ -99,8 +99,8 @@ r2(r, horseshoe :: Horseshoe) = r2(r, bound_leg(horseshoe))
 """
 Return a `Horseshoe` bound leg corresponding to a `Panel3D`.
 """
-horseshoe_line(panel :: Panel3D, drift = zeros(3)) = let (r1, r2) = bound_leg(panel); 
-    Horseshoe(Line(r1, r2), horseshoe_point(panel)) end
+horseshoe_line(panel :: Panel3D, drift = SVector(0., 0., 0.)) = let (r1, r2) = bound_leg(panel); 
+    Horseshoe(Line(r1, r2), horseshoe_point(panel) .+ drift) end
 
 """
 Compute the midpoint of the bound leg of a `Horseshoe`.

--- a/src/Aerodynamics/VortexLattice/horseshoes.jl
+++ b/src/Aerodynamics/VortexLattice/horseshoes.jl
@@ -54,6 +54,15 @@ r2(r, line :: Line) = r - r2(line)
 
 bound_leg_velocity(a, b, Γ) = Γ/4π * (1/norm(a) + 1/norm(b)) * a × b / (norm(a) * norm(b) + dot(a, b))
 
+# Finite-core model
+function bound_leg_velocity(a, b, Γ, ε) 
+    na, nb, σ = norm(a), norm(b), dot(a, b)
+    term_1    = (na^2 - σ) / √(na^2 + ε) + (nb^2 - σ) / √(nb^2 + ε)
+    term_2    = a × b / (na^2 * nb^2 - σ^2 + ε * (na^2 + nb^2 - 2 * na * nb))
+    
+    Γ/4π * term_1 * term_2
+end
+
 trailing_legs_velocities(a, b, Γ, u) = Γ/4π * (a × u / (norm(a) - dot(a, u)) / norm(a) - b × u / (norm(b) - dot(b, u)) / norm(b))
 
 total_horseshoe_velocity(a, b, Γ, u) = bound_leg_velocity(a, b, Γ) + trailing_legs_velocities(a, b, Γ, u)
@@ -73,7 +82,7 @@ A horseshoe type consisting of a bound leg of type Line represening a vortex lin
 """
 struct Horseshoe{T <: Real} <: AbstractVortexArray
     bound_leg :: Line{T}
-    # collocation_point :: SVector{3,T}
+    collocation_point :: SVector{3,T}
 end
 
 """
@@ -90,7 +99,8 @@ r2(r, horseshoe :: Horseshoe) = r2(r, bound_leg(horseshoe))
 """
 Return a `Horseshoe` bound leg corresponding to a `Panel3D`.
 """
-horseshoe_line(panel :: Panel3D) = let (r1, r2) = bound_leg(panel); (Horseshoe ∘ Line)(r1, r2) end
+horseshoe_line(panel :: Panel3D, drift = zeros(3)) = let (r1, r2) = bound_leg(panel); 
+    Horseshoe(Line(r1, r2), horseshoe_point(panel)) end
 
 """
 Compute the midpoint of the bound leg of a `Horseshoe`.

--- a/src/Aerodynamics/VortexLattice/horseshoes.jl
+++ b/src/Aerodynamics/VortexLattice/horseshoes.jl
@@ -52,19 +52,10 @@ transform(line :: Line, rotation, translation) = let trans = Translation(transla
 r1(r, line :: Line) = r - r1(line)
 r2(r, line :: Line) = r - r2(line)
 
-bound_leg_velocity(a, b, Γ) = Γ/4π * (1/norm(a) + 1/norm(b)) * a × b / (norm(a) * norm(b) + dot(a, b))
+bound_leg_velocity(a, b, Γ)    = Γ/4π * (1/norm(a) + 1/norm(b)) * a × b / (norm(a) * norm(b) + dot(a, b))
+trailing_leg_velocity(r, Γ, u) = Γ/4π * normalize(r) × u / (norm(r) - dot(r, u))
 
-# Finite-core model
-function bound_leg_velocity(a, b, Γ, ε) 
-    na, nb, σ = norm(a), norm(b), dot(a, b)
-    term_1    = (na^2 - σ) / √(na^2 + ε) + (nb^2 - σ) / √(nb^2 + ε)
-    term_2    = a × b / (na^2 * nb^2 - σ^2 + ε * (na^2 + nb^2 - 2 * na * nb))
-    
-    Γ/4π * term_1 * term_2
-end
-
-trailing_legs_velocities(a, b, Γ, u) = Γ/4π * (a × u / (norm(a) - dot(a, u)) / norm(a) - b × u / (norm(b) - dot(b, u)) / norm(b))
-
+trailing_legs_velocities(a, b, Γ, u) = trailing_leg_velocity(a, Γ, u) - trailing_leg_velocity(b, Γ, u)
 total_horseshoe_velocity(a, b, Γ, u) = bound_leg_velocity(a, b, Γ) + trailing_legs_velocities(a, b, Γ, u)
 
 horseshoe_velocity(r, line :: Line, Γ, direction) = total_horseshoe_velocity(r1(r, line), r2(r, line), Γ, direction)

--- a/src/Aerodynamics/VortexLattice/influences.jl
+++ b/src/Aerodynamics/VortexLattice/influences.jl
@@ -6,14 +6,14 @@
 
 Compute the influence coefficient of the velocity of a Horseshoe with trailing lines in a given direction ``\\hat V`` at a point ``r`` projected to a normal vector.
 """
-influence_coefficient(horseshoe :: Horseshoe, r, normal, V_hat) = dot(velocity(r, horseshoe, 1., V_hat), normal)
+influence_coefficient(horseshoe :: Horseshoe, r, normal, V_hat, finite_core = false) = dot(velocity(r, horseshoe, 1., V_hat, finite_core), normal)
 
 """
 	influence_matrix(horseshoes, collocation_points, normals, V_hat)
 
 Assemble the Aerodynamic Influence Coefficient (AIC) matrix given horseshoes, collocation points, associated normal vectors, and a unit vector representing the freestream.
 """
-influence_matrix(horseshoes :: Vector{<: Horseshoe}, collocation_points, normals, V_hat) = [ influence_coefficient(horsie_j, r_i, n_i, V_hat) for (r_i, n_i) ∈ zip(collocation_points, normals), horsie_j ∈ horseshoes ]
+influence_matrix(horseshoes :: Vector{<: Horseshoe}, collocation_points, normals, V_hat, finite_core = false) = [ influence_coefficient(horsie_j, r_i, n_i, V_hat, finite_core) for (r_i, n_i) ∈ zip(collocation_points, normals), horsie_j ∈ horseshoes ]
 
 """
 	boundary_condition(velocities, normals)

--- a/src/Geometry/PanelGeometry/3d_panels.jl
+++ b/src/Geometry/PanelGeometry/3d_panels.jl
@@ -28,12 +28,15 @@ end
 
 Panel3D(p1 :: FieldVector{3,T}, p2 :: FieldVector{3,T}, p3 :: FieldVector{3,T}, p4 :: FieldVector{3,T}) where T <: Real = Panel3D{T}(p1, p2, p3, p4)
 
+average_chord(panel :: Panel3D) = (p2(panel) - p1(panel) + p3(panel) - p4(panel)) / 2
+average_width(panel :: Panel3D) = (p4(panel) - p1(panel) + p3(panel) - p2(panel)) / 2
+
 """
     panel_area(panel :: Panel3D)
 
 Compute the area of a Panel3D.
 """
-panel_area(panel :: Panel3D) = (norm ∘ cross)((p2(panel) - p1(panel) + p3(panel) - p4(panel)) / 2, (p4(panel) - p1(panel) + p3(panel) - p2(panel)) / 2)
+panel_area(panel :: Panel3D) = (norm ∘ cross)(average_chord(panel), average_width(panel))
 
 """
     panel_coords(panel :: Panel3D)

--- a/src/Geometry/PanelGeometry/PanelGeometry.jl
+++ b/src/Geometry/PanelGeometry/PanelGeometry.jl
@@ -9,7 +9,7 @@ using CoordinateTransformations
 
 using ..AeroMDAO: Point2D, affine_2D, rotation, inverse_rotation, structtolist, sine_spacing, cosine_spacing, partition
 
-export AbstractPanel, AbstractPanel2D, Panel2D, WakePanel2D, AbstractPanel3D, Panel3D, p1, p2, p3, p4, zero, collocation_point, panel_length, transform_panel, transform_panel_points, panel_angle, panel_tangent, panel_normal, panel_location, panel_area, panel_coords, transform, midpoint, panel_points, wake_panel, wake_panels, reverse_panel, panel_velocity, panel_scalar, trailing_edge_panel, get_surface_values, panel_vector, panel_dist
+export AbstractPanel, AbstractPanel2D, Panel2D, WakePanel2D, AbstractPanel3D, Panel3D, p1, p2, p3, p4, zero, collocation_point, panel_length, transform_panel, transform_panel_points, panel_angle, panel_tangent, panel_normal, panel_location, panel_area, panel_coords, transform, midpoint, panel_points, wake_panel, wake_panels, reverse_panel, panel_velocity, panel_scalar, trailing_edge_panel, get_surface_values, panel_vector, panel_dist, average_chord, average_width
 
 ## Panel setup
 #==========================================================================================#


### PR DESCRIPTION
This implementation changes two things in the vortex lattice method setup:

1. The collocation points are added to the `Horseshoe` type, and "drift" vectors are added to displace the collocation points in the direction of the freestream velocity vector. The aim is to avoid singular errors when the trailing legs potentially intersect the collocation point otherwise. 
2. The finite-core model is added to scale the induced velocities, accounting for potential intersections between different lifting surfaces. This requires further testing and refinements, and will be continued in the target branch to avoid fragmentation. 