### PR TITLE
Fixed Point3D typo

### DIFF
--- a/src/Tools/MathTools.jl
+++ b/src/Tools/MathTools.jl
@@ -13,7 +13,7 @@ end
 x(p :: Point2D) = p.x
 y(p :: Point2D) = p.y
 
-struct Point3D{T <: Real} <: FieldVector{2, T} 
+struct Point3D{T <: Real} <: FieldVector{3, T} 
     x :: T
     y :: T
     z :: T


### PR DESCRIPTION
# Pull Request Template

## Description

`Point3D` constructor contained a typo. Correct `SVector` length should be 3 instead of 2.

Fixes # (issue)

Change the pre-allocated length to be 3.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] A 3D point can be constructed correctly

Test Configuration:
* Firmware version: Mac OS 12.2.1 (21D62)
* Hardware: MacBook Pro 16 inch (late 2019)
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings