### PR TITLE
HalfWing geometry automatic differentiation fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AeroMDAO"
 uuid = "ae1513eb-aba2-415b-9b88-80f66c7c7c76"
 authors = ["GodotMisogi <arjitseth@gmail.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ If you use AeroMDAO in your research, please cite the following until any releva
   author  = {Arjit Seth, Stephane Redonnet, Rhea P. Liem},
   title   = {AeroMDAO},
   url     = {https://github.com/GodotMisogi/AeroMDAO},
-  version = {0.3.9},
-  date    = {2022-4-06},
+  version = {0.3.10},
+  date    = {2022-4-21},
 }
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,8 +52,8 @@ If you use AeroMDAO in your research, please cite the following until any releva
   author  = {Arjit Seth, Rhea P. Liem, Stephane Redonnet},
   title   = {AeroMDAO},
   url     = {https://github.com/GodotMisogi/AeroMDAO},
-  version = {0.3.9},
-  date    = {2021-04-06},
+  version = {0.3.10},
+  date    = {2021-04-21},
 }
 ```
 

--- a/examples/vortex_lattice_method/stability_aircraft.jl
+++ b/examples/vortex_lattice_method/stability_aircraft.jl
@@ -129,20 +129,22 @@ println("Spiral Stability      γ: $γ")
 ## Plotting everything
 using Plots
 
+gr(dpi = 300)
+
 wing_plan  = plot_planform(wing)
 htail_plan = plot_planform(htail)
 vtail_plan = plot_planform(vtail)
 
 #
 z_limit = b
-aircraft_plot =
-plot(xaxis = "x", yaxis = "y", zaxis = "z",
-     camera = (30, 60),
-     xlim = (0, z_limit),
-    #  ylim = (-z_limit/2, z_limit/2),
-     zlim = (-z_limit/2, z_limit/2),
-    #  size = (1920, 1080),
-    #  legend = false
+aircraft_plot = plot(
+    xaxis = "x", yaxis = "y", zaxis = "z",
+    camera = (30, 60),
+    xlim = (0, z_limit),
+    # ylim = (-z_limit/2, z_limit/2),
+    zlim = (-z_limit/2, z_limit/2),
+    size = (900, 600),
+    # legend = false
     )
 
 plot!(wing_plan[:,1], wing_plan[:,2], wing_plan[:,3],  label = "Wing")
@@ -155,7 +157,7 @@ scatter!(Tuple(vtail_mac), color = :green, label = "Vertical Tail MAC")
 
 scatter!(Tuple(loc_np), color = :orange, label = "Neutral Point")
 scatter!(Tuple(loc_cp), color = :brown, label = "Center of Pressure")
-# savefig(aircraft_plot, "Aircraft.png")
+savefig(aircraft_plot, "AircraftData.png")
 plot!()
 
 

--- a/examples/vortex_lattice_method/vlm_wing.jl
+++ b/examples/vortex_lattice_method/vlm_wing.jl
@@ -4,7 +4,7 @@ using AeroMDAO
 ## Wing section setup
 wing_right = HalfWing(
                       foils     = fill(naca4((0,0,1,2)), 3),
-                      chords    = [1.0, 0.6, 0.2],
+                      chords    = [2.0, 1.6, 0.2],
                       twists    = [0.0, 0.0, 0.0],
                       spans     = [2.5, 0.5],
                       dihedrals = [5., 5.],
@@ -66,7 +66,7 @@ CDv_plate   = profile_drag_coefficient(wing_mesh, x_tr, refs)
 ## Local-dissipation drag estimation (WRONG???)
 cam_panels  = camber_panels(wing_mesh)
 edge_speeds = surface_velocities(system).wing
-CDv_diss    = profile_drag_coefficient(wing, x_tr, edge_speeds, cam_panels, refs)
+CDv_diss    = profile_drag_coefficient(wing_mesh, x_tr, edge_speeds, refs)
 
 ## Viscous drag coefficient
 CDv = CDv_plate

--- a/src/Aerodynamics/LinearVortexSource/singularities.jl
+++ b/src/Aerodynamics/LinearVortexSource/singularities.jl
@@ -52,20 +52,32 @@ function linear_vortex_velocity_a(γ1, x, z, x1, x2)
     r1, r2, θ1, θ2 = polar_transform(x, z, x1, x2)
     d = x2 - x1
 
-    ua = term_2(x2, x, z, r1, r2, θ1, θ2)
-    wa = term_1(x2, x, z, d, r1, r2, θ1, θ2)
+    # ua = term_2(x2, x, z, r1, r2, θ1, θ2)
+    # wa = term_1(x2, x, z, d, r1, r2, θ1, θ2)
 
-    @. γ1 / (2π * d) * SVector(-ua, -wa)
+    dlogr = log(r1 / r2)
+    dθ    = (θ2 - θ1)
+
+    u =     dθ / 2π + (z * dlogr     - x * dθ) / (2π * d)
+    w = -dlogr / 2π + (x * dlogr - d + z * dθ) / (2π * d)
+    
+    γ1 * SVector(u, w)
 end
 
 function linear_vortex_velocity_b(γ2, x, z, x1, x2)
     r1, r2, θ1, θ2 = polar_transform(x, z, x1, x2)
     d = x2 - x1
 
-    ub = term_2(x1, x, z, r1, r2, θ1, θ2)
-    wb = term_1(x1, x, z, d, r1, r2, θ1, θ2)
+    # ub = term_2(x1, x, z, r1, r2, θ1, θ2)
+    # wb = term_1(x1, x, z, d, r1, r2, θ1, θ2)
 
-    @. γ2 / (2π * d) * SVector(ub, wb)
+    dlogr = log(r1 / r2)
+    dθ    = (θ2 - θ1)
+
+    u = -(z * dlogr     - x * dθ) / (2π * d)
+    w = -(x * dlogr - d + z * dθ) / (2π * d)
+
+    γ2 * SVector(u, w)
 end
 
 
@@ -89,9 +101,9 @@ function constant_source_stream(σ, x, z, x1, x2)
     # Branch cuts
     dψ = x2
     if (θ1 + θ2) > π
-      ψ -= 0.25 * dψ
+        ψ -= 0.25 * dψ
     else
-      ψ += 0.75 * dψ
+        ψ += 0.75 * dψ
     end
 end
 
@@ -108,6 +120,10 @@ function linear_source_stream_minus(σ, x, z, x1, x2)
     r1, r2, θ1, θ2 = polar_transform(x, z, x1, x2)
     d = x2 - x1
 
+    # Branch cuts
+    if θ1 < 0.; θ1 += 2π; end
+    if θ2 < 0.; θ2 += 2π; end
+
     # Singularity checks
     ϵ = 1e-10;
     if r1 < ϵ; logr1 = 0.; θ1 = π; θ2 = π; else logr1 = log(r1); end
@@ -121,39 +137,59 @@ function linear_source_stream_plus(σ, x, z, x1, x2)
     d = x2 - x1
     ψ_m = linear_source_stream_minus(1., x, z, x1, x2)
 
+    # Branch cuts
+    if θ1 < 0.; θ1 += 2π; end
+    if θ2 < 0.; θ2 += 2π; end
+
     # Singularity checks
     ϵ = 1e-10;
     if r1 < ϵ; logr1 = 0.; θ1 = π; θ2 = π; else logr1 = log(r1); end
     if r2 < ϵ; logr2 = 0.; θ1 = 0.; θ2 = 0.; else logr2 = log(r2); end
 
-    ψ_p = σ / d * (x * ψ_m + 1/4π * (r2^2 * θ2 - r1^2 * θ1))
+    ψ_p = σ / d * (x * ψ_m + 1/4π * (r2^2 * θ2 - r1^2 * θ1 - z * d))
 end
 
 # Velocities
 function linear_source_velocity_a(σ1, x, z, x1, x2)
     r1, r2, θ1, θ2 = polar_transform(x, z, x1, x2)
     d = x2 - x1
-    if abs(z) <= 1e-12
-        ua, wa = boundary_term(x2, x, d)
-        σ1 .* SVector(ua, -wa)
-    else
-        ua = term_1(x2, x, z, d, r1, r2, θ1, θ2)
-        wa = term_2(x2, x, z, r1, r2, θ1, θ2)
+    # if abs(z) <= 1e-12
+        # ua, wa = # boundary_term(x2, x, d)
+        # σ1 .* SVector(ua, -wa)
+    # else
+        # ua = term_1(x2, x, z, d, r1, r2, θ1, θ2)
+        # wa = term_2(x2, x, z, r1, r2, θ1, θ2)
 
-        @. σ1 / (2π * (x2 - x1)) * SVector(ua, -wa)
-    end
+        # @. σ1 / (2π * (x2 - x1)) * SVector(ua, -wa)
+    # end
+
+    dlogr = log(r1 / r2)
+    dθ    = (θ2 - θ1)
+
+    u = dlogr / 2π - (x * dlogr - d + z * dθ) / (2π * d)
+    w =    dθ / 2π + (z * dlogr     - x * dθ) / (2π * d)
+
+    σ1 * SVector(u, w)
 end
 
 function linear_source_velocity_b(σ2, x, z, x1, x2)
     r1, r2, θ1, θ2 = polar_transform(x, z, x1, x2)
     d = x2 - x1
-    if abs(z) <= 1e-12
-        ub, wb = boundary_term(x1, x, d)
-        σ2 .* SVector(-ub, wb)
-    else
-        ub = term_1(x1, x, z, d, r1, r2, θ1, θ2)
-        wb = term_2(x1, x, z, r1, r2, θ1, θ2)
+    # if abs(z) <= 1e-12
+    #     ub, wb = # boundary_term(x1, x, d)
+    #     σ2 .* SVector(-ub, wb)
+    # else
+    #     ub = term_1(x1, x, z, d, r1, r2, θ1, θ2)
+    #     wb = term_2(x1, x, z, r1, r2, θ1, θ2)
 
-        @. σ2 / (2π * (x2 - x1)) * SVector(-ub, wb)
-    end
+    #     @. σ2 / (2π * (x2 - x1)) * SVector(-ub, wb)
+    # end
+
+    dlogr = log(r1 / r2)
+    dθ    = (θ2 - θ1)
+
+    u =  (x * dlogr - d + z * dθ) / (2π * d)
+    w = -(z * dlogr     - x * dθ) / (2π * d)
+
+    σ2 * SVector(u, w)
 end

--- a/src/Geometry/AircraftGeometry/Wings/halfwing.jl
+++ b/src/Geometry/AircraftGeometry/Wings/halfwing.jl
@@ -11,13 +11,13 @@
 
 Definition for a `HalfWing` consisting of ``N+1`` `Foil`s, their associated chord lengths ``c`` and twist angles ``ι``, for ``N`` sections with span lengths ``b``, dihedrals ``δ`` and leading-edge sweep angles ``Λ_{LE}``, with all angles in degrees.
 """
-struct HalfWing{S <: AbstractVector{<: Real}, F <: AbstractVector{<: AbstractFoil}, N <: AbstractAffineMap} <: AbstractWing
-    foils      :: F
-    chords     :: S
-    twists     :: S
-    spans      :: S
-    dihedrals  :: S
-    sweeps     :: S
+struct HalfWing{T <: Real, N <: AbstractAffineMap} <: AbstractWing
+    foils      :: Vector{<: AbstractFoil}
+    chords     :: Vector{T}
+    twists     :: Vector{T}
+    spans      :: Vector{T}
+    dihedrals  :: Vector{T}
+    sweeps     :: Vector{T}
     affine     :: N
 end
 
@@ -36,8 +36,11 @@ function HalfWing(foils, chords, twists, spans, dihedrals, sweeps, w_sweep = 0.,
     # TODO: Perform automatic cosine interpolation of foils with minimum number of points for surface construction?
     # foils = cosine_interpolation.(foils, 60)
 
+    T = promote_type(eltype(chords), eltype(twists), eltype(spans), eltype(dihedrals), eltype(sweeps), typeof(w_sweep))
+    N = typeof(affine)
+
     # Convert angles to radians, adjust twists to leading edge, and generate HalfWing
-    HalfWing(foils, chords, -deg2rad.(twists), spans, deg2rad.(dihedrals), sweeps, affine)
+    HalfWing{T,N}(foils, chords, -deg2rad.(twists), spans, deg2rad.(dihedrals), sweeps, affine)
 end
 
 function check_wing(foils, chords, twists, spans, dihedrals, sweeps)
@@ -60,7 +63,7 @@ function HalfWing(;
         w_sweep   = 0.0,
         position  = zeros(3),
         angle     = 0.,
-        axis      = SVector(0., 1., 0.)
+        axis      = [0., 1., 0.]
     )
 
     HalfWing(foils, chords, twists, spans, dihedrals, sweeps, w_sweep, position, angle, axis)

--- a/src/Geometry/PanelGeometry/2d_panels.jl
+++ b/src/Geometry/PanelGeometry/2d_panels.jl
@@ -49,7 +49,7 @@ function panel_angle(panel :: AbstractPanel2D)
     # ifelse(θ < 0., θ + 2π, θ) # Branch cut
 end
 
-panel_normal(panel :: AbstractPanel2D) = let (x, y) = panel_vector(panel); [-y; x] end
+panel_normal(panel :: AbstractPanel2D) = let (x, y) = panel_vector(panel); normalize([-y; x]) end
 
 tangent_vector(panel :: AbstractPanel2D) = rotation(1., 0., -panel_angle(panel))
 
@@ -126,7 +126,7 @@ function panel_velocity(velocity_func, strength, panel_j :: AbstractPanel2D, pan
     u, w = panel_velocity(velocity_func, strength, panel_j, x, y)
 end
 
-panel_velocity(f1, f2, str1, str2, panel :: AbstractPanel2D, x, y) = panel_velocity(f1, str1, panel, x, y) .+ panel_velocity(f2, str2, panel, x, y)
+panel_velocity(f1, f2, str1, str2, panel :: AbstractPanel2D, x, y) = panel_velocity(f1, str1, panel, x, y) + panel_velocity(f2, str2, panel, x, y)
 
 panel_velocity(f1, f2, str_j1, str_j2, panel_j :: AbstractPanel2D, panel_i :: AbstractPanel2D) = panel_velocity(f1, str_j1, panel_j, panel_i) .+ panel_velocity(f2, str_j2, panel_j, panel_i)
 


### PR DESCRIPTION
Fixes issue in `HalfWing` geometry differentiation incompatibility with `CoordinateTransformations` by type promotion in the outer constructor.